### PR TITLE
added ability to parse gpx track to get all geocaches around it

### DIFF
--- a/geotoad.rb
+++ b/geotoad.rb
@@ -35,6 +35,7 @@ require 'find' # for cleanup
 require 'zlib'
 require 'cgi'
 require 'net/https' # for openssl
+require 'rexml/document'  # for xml parsing
 
 class GeoToad
 
@@ -135,12 +136,6 @@ class GeoToad
       exit
     end
 
-    if ! @option['clearCache'] && ! @option['myLogs'] && ! @option['myTrackables'] && ! @queryArg
-      displayError "You forgot to specify a #{@queryType} search argument"
-      @uin.usage
-      exit
-    end
-
     if (! @option['user']) || (! @option['password'])
       debug "No user/password option given, loading from config."
       (@option['user'], @option['password']) = @uin.loadUserAndPasswordFromConfig()
@@ -187,6 +182,21 @@ class GeoToad
 
     @limitPages = @option['limitSearchPages'].to_i
     debug "Limiting search to #{@limitPages.inspect} pages" if (@limitPages != 0)
+
+    # check for a gpx track to pase
+    # uses the maxDistance for its calculation so needs to be after distance determination
+    if @option['gpxTrack'] and !@queryArg
+      @queryType         = 'coord'
+      
+      # set the GPX Trackpoints as query array
+        @queryArg        = parseGPXTrack(@option['gpxTrack'])
+    end
+
+    if ! @option['clearCache'] && ! @option['myLogs'] && ! @option['myTrackables'] && ! @queryArg
+      displayError "You forgot to specify a #{@queryType} search argument"
+      @uin.usage
+      exit
+    end
 
     return @option
   end
@@ -1015,6 +1025,45 @@ class GeoToad
     } # end format loop
   end
 
+  ## parse the given gpx file to get all coordinates to check
+  def parseGPXTrack(file)
+
+    dist = @distanceMax * $MILE2KM
+    doc = REXML::Document.new(File.open(file))
+    
+    # get first coord
+    last = [doc.elements['gpx/trk/trkseg/trkpt'].attributes["lat"].to_f, doc.elements['gpx/trk/trkseg/trkpt'].attributes["lon"].to_f]
+
+    # Start of track as first 
+    queryCoords = last[0].to_s + ", " + last[1].to_s
+
+    doc.elements.each("gpx/trk/trkseg/trkpt"){ 
+      |e| 
+      curr = [e.attributes["lat"].to_f, e.attributes["lon"].to_f]
+      
+      # check if far enough apart
+      if (distanceBetweenCoords last,curr ) > (dist/3)
+        last = curr
+        queryCoords += ":" + curr[0].to_s + ", " + curr[1].to_s
+      end # end of for each
+    }
+
+    return queryCoords
+  end
+
+  ## it calculates the approximated distance between the two given Coords
+  ## it's not perfect, but fast and on short distances good enough
+  def distanceBetweenCoords loc1, loc2
+    rad_per_deg = Math::PI/180    # 1° = PI / 180 Radians
+    erkm = 6371                   # Earth radius in kilometers
+    
+    d1 = (loc2[0] - loc1[0]) * rad_per_deg    # Delta of lats
+    d2 = (loc2[1] - loc1[1]) * rad_per_deg    # Delta of lons
+    cml = Math::cos((loc1[0] + loc2[0]) / 2)  # cos Mean latitude
+
+    return erkm * Math::sqrt(d1*d1 + (cml*d2)**2) # D = R sqrt( d1² + (cml*d2)² )
+  end
+
 end
 
 # for Ocra build
@@ -1097,7 +1146,7 @@ while true
   end
 
   count = 0
-  if options['queryArg'] || options['myLogs'] || options['myTrackables']
+  if options['queryArg'] || options['myLogs'] || options['myTrackables'] || options['gpxTrack']
     count = cli.downloadGeocacheList()
   end
   if count < 1

--- a/interface/input.rb
+++ b/interface/input.rb
@@ -121,7 +121,8 @@ class Input
       [ "--minLongitude", "--longMin",            GetoptLong::REQUIRED_ARGUMENT ],
       [ "--maxLongitude", "--longMax",            GetoptLong::REQUIRED_ARGUMENT ],
       [ "--minLatitude",  "--latMin",             GetoptLong::REQUIRED_ARGUMENT ],
-      [ "--maxLatitude",  "--latMax",             GetoptLong::REQUIRED_ARGUMENT ]
+      [ "--maxLatitude",  "--latMax",             GetoptLong::REQUIRED_ARGUMENT ],
+      [ "--gpxTrack",     "--track",              GetoptLong::REQUIRED_ARGUMENT ]
     ) || usage
 
     # put the stupid crap in a hash. Much nicer to deal with.


### PR DESCRIPTION
Hey I'm Sören Krollmann and riding bike a lot and love to go out and find caches. since a view years i combine it and go out cycling a track (for a view days) and also search caches. Until now i either made the radius big enough to fit my track in (makes a huge file; 3000+ caches) or is split it up in multiple smaller locations on the track. But by hand this is very time consuming. So i decided to add it to your awesome program.

now with ./geotoad.rb ... --gpxTrack ./track1.gpx -c traditional -y 0.5km -o ./caches1.gpx -O geotoad reads my track and searches for me all geocaches within 0.5km around it.

there fore i used the ability that your program already able to check multiple locations if they are in the form Coord1:Coord2:Cord3 ... so i only had to add a peace of code that generated a list of cords out of a gpx track and set it as '@queryArg'. I implemented also that the checked coordinates are fare enough away from each other so that u not check each centimeter again. The distance between two checked coords depends on the -y option so that if u check 2km around

 the track that the coords are more apart than if u only check 0.5km around it.

I attached a screen shot of what u get with my modification.  Blue is the track for riding and the red marks are all the caches (traditional) around.

I'm from Germany and my English isn't the best so if there is something not understandable please contact me.

i would be extremely happy if i made it in ur master

![screenshot from 2016-05-29 19-51-20](https://cloud.githubusercontent.com/assets/1176499/15635162/59521938-25d7-11e6-8e94-e286a01575bf.png)

kind regards 
Kr0llx
