### PR TITLE
replace URI.escape for compatibility with ruby 3.0

### DIFF
--- a/lib/output.rb
+++ b/lib/output.rb
@@ -1334,7 +1334,7 @@ class Output
     else
       location = 'Undetermined'
     end
-    coord_query = URI.escape(sprintf("%.6f,%.6f", cache['latdata'].to_f, cache['londata'].to_f))
+    coord_query = URI.encode_www_form_component(sprintf("%.6f,%.6f", cache['latdata'].to_f, cache['londata'].to_f), enc=nil)
     available = (not cache['disabled'] and not cache['archived'])
     archived = cache['archived']
 


### PR DESCRIPTION
URI.escape did a lot of magic to differentiate between URL components to escape them differently.
Since we only need to escape a query to use in a map http link, we use the `encode_www_form_component` function here.

fixes #366